### PR TITLE
Fixed CLI argument with hyphen bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `file_checksum_method` config option that can be used to select whether to use file content hashing (default)
 or file modification timestamps for calculating the checksum of an external file represented by a `Path` object
 
+### Fixed
+- Fixed a bug where CLI arguments containing a hyphen would not be parsed correctly when used in a `Lab` 
+
 ## [0.0.6] - 2022-05-17
 ### Added
 - Added py.typed file to signal to downstream user's that alkymi has type annotations

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -115,9 +115,9 @@ class Lab:
             # For iterables (e.g. lists), the "type" keyword is actually the type of elements in the iterable
             if issubclass(arg.type, Iterable) and not arg.type == str:
                 subtype = arg.subtype if arg.subtype is not None else str
-                parser.add_argument("--{}".format(arg_name), type=subtype, nargs="*")
+                parser.add_argument("--{}".format(arg_name), type=subtype, nargs="*", dest=arg_name)
             else:
-                parser.add_argument("--{}".format(arg_name), type=arg.type)
+                parser.add_argument("--{}".format(arg_name), type=arg.type, dest=arg_name)
 
     def __repr__(self) -> str:
         """

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -104,13 +104,14 @@ def test_lab_open() -> None:
     assert str(alk.Status.Ok) in status_msg
 
 
-def test_lab_arg() -> None:
+@pytest.mark.parametrize("arg_name", ("an_arg", "an-arg"))
+def test_lab_arg(arg_name: str) -> None:
     """
     Test providing an argument to a recipe through a lab's command line interface
     """
     AlkymiConfig.get().cache = False
 
-    arg = alk.arg(42, name="an_arg")
+    arg = alk.arg(42, name=arg_name)
     output = 0
 
     @alk.recipe()


### PR DESCRIPTION
This PR fixed #22. CLI arguments containing hyphens now work as expected.