### PR TITLE
Live program outputs from call() utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 or file modification timestamps for calculating the checksum of an external file represented by a `Path` object
 
 ### Fixed
-- Fixed a bug where CLI arguments containing a hyphen would not be parsed correctly when used in a `Lab` 
+- Fixed a bug where CLI arguments containing a hyphen would not be parsed correctly when used in a `Lab`
+
+### Changed
+- Made the `call()` utility function print program outputs (stdout) to stdout by default - this can be controlled using
+the `echo_output_to_stream` argument.
 
 ## [0.0.6] - 2022-05-17
 ### Added

--- a/alkymi/utils.py
+++ b/alkymi/utils.py
@@ -5,20 +5,49 @@ from typing import List, TextIO, Optional
 from .logging import log
 
 
-def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr) -> subprocess.CompletedProcess:
+def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr,
+         echo_output_to_stream: Optional[TextIO] = sys.stdout) -> subprocess.CompletedProcess:
     """
     Utility command to run a system command and return the result (stdout and stderr will also be printed to the debug
     log)
 
     :param args: The arguments representing the command to run, e.g. ["echo", "test"]
     :param echo_error_to_stream: A stream to which to echo the call's stderr on a non-zero exit code
+    :param echo_output_to_stream: A stream to which to echo the call's stdout while the command is executing
     :return: The result of the execution as a subprocess.CompletedProcess instance
     """
-    proc = subprocess.run(args, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    log.debug(proc.stdout)
-    log.debug(proc.stderr)
+    # Buffer one line at a time if echoing live, otherwise just use the default
+    buffer_size = 1 if echo_output_to_stream is not None else -1
+    proc = subprocess.Popen(args, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            bufsize=buffer_size)
+
+    # Since we set these to PIPE, these should never be None
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+
+    stdout: str = ""
+    if echo_output_to_stream is not None:
+        # Print each line to the stream as it arrives
+        while proc.poll() is None:
+            line = proc.stdout.readline()
+            echo_output_to_stream.write(line)
+            stdout += line
+    else:
+        # Otherwise, simply wait for the command to finish and then grab stdout
+        proc.wait()
+        stdout = proc.stdout.read()
+
+    stderr = proc.stderr.read()
+
+    # Send to alkymi log
+    log.debug(stdout)
+    log.debug(stderr)
+
     # Always forward error messages to stderr if needed
-    if echo_error_to_stream is not None and proc.returncode:
-        echo_error_to_stream.write(proc.stderr)
-    proc.check_returncode()
-    return proc
+    if echo_error_to_stream is not None and proc.returncode != 0:
+        echo_error_to_stream.write(stderr)
+
+    # Raise an error on failure
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, proc.args, stdout, stderr)
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,7 @@ for i in range({}):
     # We have to set 'PYTHONUNBUFFERED' to avoid buffering inside the subprocess itself
     os.environ["PYTHONUNBUFFERED"] = "1"
     alkymi.utils.call(["python3", "-c", program], echo_output_to_stream=stream)
-    os.unsetenv("PYTHONUNBUFFERED")
+    del os.environ['PYTHONUNBUFFERED']
 
     # Stop reader thread
     process_stream = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,7 +68,7 @@ import time
 
 for i in range({}):
     print(i)
-    time.sleep(0.01)
+    time.sleep(0.1)
     """.format(num_outputs)
 
     alkymi.utils.call(["python3", "-c", program], echo_output_to_stream=stream)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import io
+import os
 import subprocess
 import threading
 import time
@@ -68,10 +69,13 @@ import time
 
 for i in range({}):
     print(i)
-    time.sleep(0.1)
+    time.sleep(0.01)
     """.format(num_outputs)
 
+    # We have to set 'PYTHONUNBUFFERED' to avoid buffering inside the subprocess itself
+    os.environ["PYTHONUNBUFFERED"] = "1"
     alkymi.utils.call(["python3", "-c", program], echo_output_to_stream=stream)
+    os.unsetenv("PYTHONUNBUFFERED")
 
     # Stop reader thread
     process_stream = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import io
 import subprocess
+import threading
+import time
 
 import pytest
 
@@ -29,3 +31,55 @@ def test_call_error():
         alkymi.utils.call(["python3", "-c", "raise RuntimeError('{}')".format(error_str)], echo_error_to_stream=stream)
     stream.seek(0)
     assert error_str in stream.read()
+
+
+def test_call_updates():
+    """
+    Test that the utils.call() function can correctly return stdout line-by-line while a command is executing (to enable
+    live output).
+    """
+    num_outputs = 5
+
+    stream = io.StringIO()
+    times = []
+    process_stream = True
+
+    # Use a thread to monitor the stream continuously while the command is being executed
+    def _monitor_thread():
+        last_output = ""
+        while process_stream:
+            output = stream.getvalue()
+
+            # If output hasn't changed, keep trying
+            if not output or output == last_output:
+                time.sleep(0.001)
+                continue
+
+            # Store the last output and the timestamp
+            last_output = output
+            times.append(time.time())
+
+    stream_monitor = threading.Thread(target=_monitor_thread)
+    stream_monitor.start()
+
+    # Script to execute - simply prints a number of numbers, each on a separate line followed by a sleep
+    program = """
+import time
+
+for i in range({}):
+    print(i)
+    time.sleep(0.01)
+    """.format(num_outputs)
+
+    alkymi.utils.call(["python3", "-c", program], echo_output_to_stream=stream)
+
+    # Stop reader thread
+    process_stream = False
+    stream_monitor.join()
+
+    # We expect to have an output per iteration of the called program
+    assert len(times) == num_outputs
+
+    # Each output should have been generated at a different time than the previous one
+    for i in range(len(times) - 1):
+        assert times[i] < times[i + 1]


### PR DESCRIPTION
Made the `call()` utility function print program outputs (stdout) to stdout by default - this can be controlled using
the `echo_output_to_stream` argument.