### PR TITLE
Feat/graph based execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `networkx` as a runtime dependency
+
+### Changed
+- Rewrote the internals of alkymi to create and use a `networkx` graph (DAG) for execution. This change will enable
+future changes, like running recipes in parallel.
+- Renamed `alkymi.py` to `core.py`
+- Converted `ForeachRecipe` to have the same functional interface as a regular `Recipe`. This change enables the
+functions in `core.py` to not have special handling for `ForeachRecipe`, which makes the code simpler and easier to
+maintain.
+- Coverage step `labfile.py brew coverage` will not print which lines lack test coverage
+
+### Removed
+- Removed the special `MappedInputsDirty` status, which only applied to `ForeachRecipe`. If a `ForeachRecipe` has only
+completed a partial evaluation of its enumerable input, its status will now show `InputsChanged` instead.
+
 ## [0.0.7] - 2022-12-02
 ### Added
 - Added a `file_checksum_method` config option that can be used to select whether to use file content hashing (default)

--- a/alkymi/__init__.py
+++ b/alkymi/__init__.py
@@ -6,6 +6,7 @@ from .recipes import glob_files, file, arg  # NOQA
 from .utils import call  # NOQA
 from .types import Status  # NOQA
 from . import checksums  # NOQA
+from . import core  # NOQA
 
 # Define version
 from .version import VERSION, __version__  # NOQA

--- a/alkymi/alkymi.py
+++ b/alkymi/alkymi.py
@@ -11,7 +11,7 @@ import networkx as nx
 OutputsAndChecksums = Tuple[R, Optional[str]]
 
 
-def create_graph(recipe: Recipe[R]):
+def create_graph(recipe: Recipe[R]) -> nx.DiGraph:
     graph = nx.DiGraph()
     add_recipe_to_graph(recipe, graph)
     return graph
@@ -20,10 +20,14 @@ def create_graph(recipe: Recipe[R]):
 def add_recipe_to_graph(recipe: Recipe[R], graph: nx.DiGraph) -> Status:
     def _add_node_and_dependencies(_status: Status) -> Status:
         graph.add_node(recipe, status=_status)
+
+        # For each ingredient, add an edge from the ingredient to this recipe
         for _ingredient in recipe.ingredients:
-            graph.add_edge(recipe, _ingredient)
+            graph.add_edge(_ingredient, recipe)
+
         if isinstance(recipe, ForeachRecipe):
-            graph.add_edge(recipe, recipe.mapped_recipe)
+            # Add an edge from the mapped recipe to this recipe
+            graph.add_edge(recipe.mapped_recipe, recipe)
         return _status
 
     # Add dependencies

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -7,7 +7,6 @@ from .foreach_recipe import ForeachRecipe
 
 import networkx as nx
 
-# TODO(mathias): Rename this file to something more fitting
 OutputsAndChecksums = Tuple[R, Optional[str]]
 
 

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import Dict, Union, Any, List, Iterable, Optional, TextIO
 
-from .alkymi import compute_status_with_cache, Status
+from .alkymi import Status, compute_recipe_status
 from .logging import log
 from .recipe import Recipe
 from .recipes import Arg
@@ -102,7 +102,7 @@ class Lab:
         """
         status: Dict[Recipe, Status] = {}
         for recipe in self._recipes:
-            compute_status_with_cache(recipe, status)
+            status.update(compute_recipe_status(recipe))
         return status
 
     def _add_user_args_(self, parser: argparse.ArgumentParser) -> None:

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import Dict, Union, Any, List, Iterable, Optional, TextIO
 
-from .alkymi import Status, compute_recipe_status
+from .core import Status, compute_recipe_status
 from .logging import log
 from .recipe import Recipe
 from .recipes import Arg

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from typing import Dict, Union, Any, List, Iterable, Optional, TextIO
 
-from .core import Status, compute_recipe_status
+from .core import Status, compute_recipe_status, create_graph
 from .logging import log
 from .recipe import Recipe
 from .recipes import Arg
@@ -102,7 +102,8 @@ class Lab:
         """
         status: Dict[Recipe, Status] = {}
         for recipe in self._recipes:
-            status.update(compute_recipe_status(recipe))
+            graph = create_graph(recipe)
+            status.update(compute_recipe_status(recipe, graph))
         return status
 
     def _add_user_args_(self, parser: argparse.ArgumentParser) -> None:

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -114,8 +114,8 @@ class Recipe(Generic[R]):
         :return: The status of this recipe (will evaluate all upstream dependencies)
         """
         # Lazy import to avoid circular imports
-        from .core import compute_recipe_status
-        return compute_recipe_status(self)[self]
+        from .core import compute_recipe_status, create_graph
+        return compute_recipe_status(self, create_graph(self))[self]
 
     def __str__(self) -> str:
         return self.name

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -117,6 +117,9 @@ class Recipe(Generic[R]):
         from .alkymi import compute_recipe_status
         return compute_recipe_status(self)[self]
 
+    def __str__(self) -> str:
+        return self.name
+
     def _save_state(self) -> None:
         """
         Save the current state of this Recipe to a json file and zero or more extra data files (as needed)

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -80,7 +80,7 @@ class Recipe(Generic[R]):
         """
         return self._func(*args)
 
-    def invoke(self, inputs: Tuple[Any, ...], input_checksums: Tuple[Optional[str], ...]) -> R:
+    def invoke(self, inputs: Tuple[Any, ...], input_checksums: Tuple[Optional[str], ...]) -> None:
         """
         Evaluate this Recipe using the provided inputs. This will call the bound function on the inputs. If the result
         is already cached, that result will be used instead (the checksum is used to check this). Only the immediately
@@ -88,7 +88,6 @@ class Recipe(Generic[R]):
 
         :param inputs: The inputs provided by the ingredients (dependencies) of this Recipe
         :param input_checksums: The (possibly new) input checksum to use for checking cleanliness
-        :return: The outputs of this Recipe (which correspond to the outputs of the bound function)
         """
         log.debug('Invoking recipe: {}'.format(self.name))
         outputs = self(*inputs)
@@ -96,7 +95,6 @@ class Recipe(Generic[R]):
         self._input_checksums = input_checksums
         self._last_function_hash = self.function_hash
         self._save_state()
-        return outputs
 
     def brew(self) -> R:
         """

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -106,7 +106,7 @@ class Recipe(Generic[R]):
         :return: The outputs of this Recipe (which correspond to the outputs of the bound function)
         """
         # Lazy import to avoid circular imports
-        from .alkymi import brew
+        from .core import brew
         return brew(self)
 
     def status(self) -> Status:
@@ -114,7 +114,7 @@ class Recipe(Generic[R]):
         :return: The status of this recipe (will evaluate all upstream dependencies)
         """
         # Lazy import to avoid circular imports
-        from .alkymi import compute_recipe_status
+        from .core import compute_recipe_status
         return compute_recipe_status(self)[self]
 
     def __str__(self) -> str:

--- a/alkymi/types.py
+++ b/alkymi/types.py
@@ -15,4 +15,3 @@ class Status(enum.Enum):
     OutputsInvalid = 4  # One or more outputs of the recipe have been changed externally
     BoundFunctionChanged = 5  # The function referenced by the recipe has changed
     CustomDirty = 6  # The recipe has been marked dirty through a custom cleanliness function
-    MappedInputsDirty = 7  # One or more mapped inputs to the recipe have changed (only ForeachRecipe)

--- a/labfile.py
+++ b/labfile.py
@@ -52,7 +52,7 @@ def coverage(test_files: List[Path]) -> None:
     test(test_files)
     cov.stop()
     cov.xml_report()
-    cov.report()
+    cov.report(show_missing=True)
 
 
 @alk.recipe(transient=True)

--- a/mypy.ini
+++ b/mypy.ini
@@ -25,3 +25,6 @@ ignore_missing_imports = True
 
 [mypy-xxhash]
 ignore_missing_imports = True
+
+[mypy-networkx]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-# No requirements yet
-networkx==2.5
-matplotlib==3.4.2
+networkx>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 # No requirements yet
+networkx==2.5
+matplotlib==3.4.2

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ setuptools.setup(
         "Documentation": "https://alkymi.readthedocs.io/en/latest/",
     },
     python_requires=">=3.6",
+    install_requires=[
+        "networkx>=2.0"
+    ],
     extras_require={
         "xxhash": ["xxhash>=2.0.0"]
     },

--- a/tests/test_builtin_recipes.py
+++ b/tests/test_builtin_recipes.py
@@ -7,7 +7,7 @@ from typing import List, Dict
 
 import alkymi.recipes
 from alkymi import AlkymiConfig
-from alkymi.alkymi import Status
+from alkymi.core import Status
 from alkymi.config import FileChecksumMethod
 
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -21,6 +21,10 @@ def test_graph() -> None:
         return "b"
 
     @alk.recipe()
+    def c() -> str:
+        return "c"
+
+    @alk.recipe()
     def depends_a(a: str) -> List[str]:
         return [a, a, a, a]
 
@@ -33,18 +37,18 @@ def test_graph() -> None:
         return a + b
 
     @alk.recipe()
-    def root(foreach_a: List[str], depends_ab: str) -> str:
-        return "".join(foreach_a) + depends_ab
+    def root(foreach_a: List[str], depends_ab: str, c: str) -> str:
+        return "".join(foreach_a) + depends_ab + c
 
     graph = alk.alkymi.create_graph(root)
-    import matplotlib.pyplot as plt
-    import networkx as nx
-    plt.subplot(121)
-    color_state_map = {Status.Ok: 'green', Status.NotEvaluatedYet: 'red', Status.MappedInputsDirty: "yellow"}
-    nx.draw(graph, with_labels=True, font_weight='bold', node_color=[color_state_map[node[1]['status']]
-                                                                     for node in graph.nodes(data=True)])
-    plt.show()
-    print(graph)
+    # import matplotlib.pyplot as plt
+    # import networkx as nx
+    # plt.subplot(121)
+    # color_state_map = {Status.Ok: 'green', Status.NotEvaluatedYet: 'red', Status.MappedInputsDirty: "yellow"}
+    # nx.draw(graph, with_labels=True, font_weight='bold', node_color=[color_state_map[node[1]['status']]
+    #                                                                  for node in graph.nodes(data=True)])
+    # plt.show()
+    # print(graph)
     assert len(graph.nodes) > 1
     assert graph.has_successor(a, depends_a)
     assert graph.has_successor(a, depends_ab)
@@ -52,6 +56,11 @@ def test_graph() -> None:
     assert graph.has_successor(depends_a, foreach_a)
     assert graph.has_successor(foreach_a, root)
     assert graph.has_successor(depends_ab, root)
+    assert graph.has_successor(c, root)
+
+    result, _ = alk.alkymi.evaluate_recipe(root, graph)
+    assert result == "a_a_a_a_abc"
+
 
 
 def test_caching(caplog, tmpdir):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 
 from alkymi import AlkymiConfig
 import alkymi as alk
-from alkymi.alkymi import Status
+from alkymi.core import Status
 from alkymi.recipe import Recipe
 
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -36,7 +36,6 @@ def test_graph() -> None:
     def root(foreach_a: List[str], depends_ab: str) -> str:
         return "".join(foreach_a) + depends_ab
 
-    # root.brew()
     graph = alk.alkymi.create_graph(root)
     import matplotlib.pyplot as plt
     import networkx as nx
@@ -47,6 +46,12 @@ def test_graph() -> None:
     plt.show()
     print(graph)
     assert len(graph.nodes) > 1
+    assert graph.has_successor(a, depends_a)
+    assert graph.has_successor(a, depends_ab)
+    assert graph.has_successor(b, depends_ab)
+    assert graph.has_successor(depends_a, foreach_a)
+    assert graph.has_successor(foreach_a, root)
+    assert graph.has_successor(depends_ab, root)
 
 
 def test_caching(caplog, tmpdir):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -9,60 +9,6 @@ from alkymi.alkymi import Status
 from alkymi.recipe import Recipe
 
 
-def test_graph() -> None:
-    AlkymiConfig.get().cache = False
-
-    @alk.recipe()
-    def a() -> str:
-        return "a"
-
-    @alk.recipe()
-    def b() -> str:
-        return "b"
-
-    @alk.recipe()
-    def c() -> str:
-        return "c"
-
-    @alk.recipe()
-    def depends_a(a: str) -> List[str]:
-        return [a, a, a, a]
-
-    @alk.foreach(depends_a)
-    def foreach_a(a: str) -> str:
-        return a + "_"
-
-    @alk.recipe()
-    def depends_ab(a: str, b: str) -> str:
-        return a + b
-
-    @alk.recipe()
-    def root(foreach_a: List[str], depends_ab: str, c: str) -> str:
-        return "".join(foreach_a) + depends_ab + c
-
-    graph = alk.alkymi.create_graph(root)
-    # import matplotlib.pyplot as plt
-    # import networkx as nx
-    # plt.subplot(121)
-    # color_state_map = {Status.Ok: 'green', Status.NotEvaluatedYet: 'red', Status.MappedInputsDirty: "yellow"}
-    # nx.draw(graph, with_labels=True, font_weight='bold', node_color=[color_state_map[node[1]['status']]
-    #                                                                  for node in graph.nodes(data=True)])
-    # plt.show()
-    # print(graph)
-    assert len(graph.nodes) > 1
-    assert graph.has_successor(a, depends_a)
-    assert graph.has_successor(a, depends_ab)
-    assert graph.has_successor(b, depends_ab)
-    assert graph.has_successor(depends_a, foreach_a)
-    assert graph.has_successor(foreach_a, root)
-    assert graph.has_successor(depends_ab, root)
-    assert graph.has_successor(c, root)
-
-    result, _ = alk.alkymi.evaluate_recipe(root, graph)
-    assert result == "a_a_a_a_abc"
-
-
-
 def test_caching(caplog, tmpdir):
     """
     Test that a cache is created (in the set location), and that recipe can be restored correctly

--- a/tests/test_foreach.py
+++ b/tests/test_foreach.py
@@ -31,13 +31,10 @@ def test_execution(caplog, tmpdir):
 
     execution_counts = {f1: 0, f2: 0, f3: 0, f1.stem: 0, f2.stem: 0, f3.stem: 0}
 
-    def _check_counts(counts: Tuple[int, int, int, int, int, int]):
-        assert execution_counts[f1] == counts[0]
-        assert execution_counts[f2] == counts[1]
-        assert execution_counts[f3] == counts[2]
-        assert execution_counts[f1.stem] == counts[3]
-        assert execution_counts[f2.stem] == counts[4]
-        assert execution_counts[f3.stem] == counts[5]
+    def _check_counts(expected_counts: Tuple[int, int, int, int, int, int]):
+        actual_counts = (execution_counts[f1], execution_counts[f2], execution_counts[f3], execution_counts[f1.stem],
+                         execution_counts[f2.stem], execution_counts[f3.stem])
+        assert actual_counts == expected_counts
 
     arg = alkymi.recipes.arg([f1], name="arg")
 
@@ -67,7 +64,7 @@ def test_execution(caplog, tmpdir):
     _check_counts((1, 0, 0, 1, 0, 0))
 
     arg.set([f1, f2, f3])
-    assert file_contents.status() == Status.MappedInputsDirty
+    assert file_contents.status() == Status.IngredientDirty
     change_count.brew()
     assert file_contents.status() == Status.Ok
     _check_counts((1, 1, 1, 1, 1, 1))
@@ -86,7 +83,7 @@ def test_execution(caplog, tmpdir):
 
     # Test that changing an ingredient forces reevaluation of all foreach inputs
     arg.set([f1, f2, f3])
-    assert change_count.status() == Status.MappedInputsDirty
+    assert change_count.status() == Status.IngredientDirty
     change_count.brew()
     assert change_count.status() == Status.Ok
     _check_counts((3, 2, 2, 3, 2, 2))

--- a/tests/test_foreach.py
+++ b/tests/test_foreach.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple, Union
 
 import alkymi.recipes
 from alkymi import AlkymiConfig
-from alkymi.alkymi import Status
+from alkymi.core import Status
 import alkymi as alk
 
 # We use these globals to avoid altering the hashes of bound functions when any of these change

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,7 +3,6 @@
 from typing import List
 from alkymi import AlkymiConfig
 import alkymi as alk
-from alkymi.alkymi import Status
 
 
 def test_graph_construction() -> None:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -64,7 +64,3 @@ def test_create_graph() -> None:
     assert graph.has_successor(foreach_a, root)
     assert graph.has_successor(depends_ab, root)
     assert graph.has_successor(c, root)
-
-    # # Evaluating the graph should result in the following output
-    # result, _ = alk.core.evaluate_recipe(root, graph)
-    # assert result == "a_a_a_a_abc"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -5,7 +5,7 @@ from alkymi import AlkymiConfig
 import alkymi as alk
 
 
-def test_graph_construction() -> None:
+def test_create_graph() -> None:
     """
     Test that a Directed Acyclic Graph (DAG) is correctly created from a set of recipes with dependencies on each other
     """
@@ -65,6 +65,6 @@ def test_graph_construction() -> None:
     assert graph.has_successor(depends_ab, root)
     assert graph.has_successor(c, root)
 
-    # Evaluating the graph should result in the following output
-    result, _ = alk.core.evaluate_recipe(root, graph)
-    assert result == "a_a_a_a_abc"
+    # # Evaluating the graph should result in the following output
+    # result, _ = alk.core.evaluate_recipe(root, graph)
+    # assert result == "a_a_a_a_abc"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+from typing import List
+from alkymi import AlkymiConfig
+import alkymi as alk
+from alkymi.alkymi import Status
+
+
+def test_graph_construction() -> None:
+    """
+    Test that a Directed Acyclic Graph (DAG) is correctly created from a set of recipes with dependencies on each other
+    """
+    AlkymiConfig.get().cache = False
+
+    @alk.recipe()
+    def unused() -> None:
+        return None
+
+    @alk.recipe()
+    def a() -> str:
+        return "a"
+
+    @alk.recipe()
+    def b() -> str:
+        return "b"
+
+    @alk.recipe()
+    def c() -> str:
+        return "c"
+
+    @alk.recipe()
+    def depends_a(a: str) -> List[str]:
+        return [a, a, a, a]
+
+    @alk.foreach(depends_a)
+    def foreach_a(a: str) -> str:
+        return a + "_"
+
+    @alk.recipe()
+    def depends_ab(a: str, b: str) -> str:
+        return a + b
+
+    @alk.recipe()
+    def root(foreach_a: List[str], depends_ab: str, c: str) -> str:
+        return "".join(foreach_a) + depends_ab + c
+
+    # Create a graph from the 'root' recipe (this will automatically traverse the dependencies)
+    graph = alk.alkymi.create_graph(root)
+
+    # Graph should be directed and not a multi-graph (no parallel edges)
+    assert graph.is_directed()
+    assert not graph.is_multigraph()
+
+    # Graph should have one node for each recipe
+    assert len(graph.nodes) == len([a, b, c, depends_a, foreach_a, depends_ab, root])
+
+    # The unused recipe should not be in the graph
+    assert not graph.has_node(unused)
+
+    # The graph should have the following edges (dependencies)
+    assert graph.has_successor(a, depends_a)
+    assert graph.has_successor(a, depends_ab)
+    assert graph.has_successor(b, depends_ab)
+    assert graph.has_successor(depends_a, foreach_a)
+    assert graph.has_successor(foreach_a, root)
+    assert graph.has_successor(depends_ab, root)
+    assert graph.has_successor(c, root)
+
+    # Evaluating the graph should result in the following output
+    result, _ = alk.alkymi.evaluate_recipe(root, graph)
+    assert result == "a_a_a_a_abc"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -44,7 +44,7 @@ def test_graph_construction() -> None:
         return "".join(foreach_a) + depends_ab + c
 
     # Create a graph from the 'root' recipe (this will automatically traverse the dependencies)
-    graph = alk.alkymi.create_graph(root)
+    graph = alk.core.create_graph(root)
 
     # Graph should be directed and not a multi-graph (no parallel edges)
     assert graph.is_directed()
@@ -66,5 +66,5 @@ def test_graph_construction() -> None:
     assert graph.has_successor(c, root)
 
     # Evaluating the graph should result in the following output
-    result, _ = alk.alkymi.evaluate_recipe(root, graph)
+    result, _ = alk.core.evaluate_recipe(root, graph)
     assert result == "a_a_a_a_abc"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import io
-import os
 import subprocess
 import threading
 import time


### PR DESCRIPTION
### Added
- Added `networkx` as a runtime dependency

### Changed
- Rewrote the internals of alkymi to create and use a `networkx` graph (DAG) for execution. This change will enable
future changes, like running recipes in parallel.
- Renamed `alkymi.py` to `core.py`
- Converted `ForeachRecipe` to have the same functional interface as a regular `Recipe`. This change enables the
functions in `core.py` to not have special handling for `ForeachRecipe`, which makes the code simpler and easier to
maintain.
- Coverage step `labfile.py brew coverage` will not print which lines lack test coverage

### Removed
- Removed the special `MappedInputsDirty` status, which only applied to `ForeachRecipe`. If a `ForeachRecipe` has only
completed a partial evaluation of its enumerable input, its status will now show `InputsChanged` instead.