### PR TITLE
Parallel Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `networkx` as a runtime dependency
+- Added support for parallel execution - the `brew()` function now takes a `jobs` parameter that controls
+parallelization of the recipe evaluation.
+- Added support for parallel execution to the `Lab` CLI - use `--jobs` or `-j` when calling `brew` to run pipeline in
+parallel
 
 ### Changed
 - Rewrote the internals of alkymi to create and use a `networkx` graph (DAG) for execution. This change will enable
@@ -17,6 +21,8 @@ future changes, like running recipes in parallel.
 functions in `core.py` to not have special handling for `ForeachRecipe`, which makes the code simpler and easier to
 maintain.
 - Coverage step `labfile.py brew coverage` will not print which lines lack test coverage
+- The `invoke` and `invoke_foreach` functions have been moved from `recipe.py` and `foreach_recipe.py` into `core.py`
+to allow more control over the execution flow.
 
 ### Removed
 - Removed the special `MappedInputsDirty` status, which only applied to `ForeachRecipe`. If a `ForeachRecipe` has only

--- a/README.md
+++ b/README.md
@@ -48,21 +48,6 @@ result = long_running_task.brew()  # == np.ndarray([42])
 
 Or one of the examples, e.g. [MNIST](https://alkymi.readthedocs.io/en/latest/examples/mnist.html).
 
-## Upcoming Features
-The following features are being considered for future implementation:
-* Type annotations propagated from bound functions to recipes
-* Support for call/type checking all recipes (e.g. by adding a `check` command to `Lab`)
-* Cache maintenance functionality
-* Parallel execution of pipeline
-
-## Known Issues
-* alkymi currently doesn't check custom objects for altered external files when computing cleanliness (e.g. `MyClass`
-has a `self._some_path` that points to a file somewhere outside alkymi's internal cache)
-* `alk.foreach()` currently only supports enumerable inputs of type `List` or `Dict`
-* Recipes marked `transient` will always be dirty, and thus always require reevaluation. This functionality should be
-replaced by a proper means of creating recipes that don't cache outputs, but only run when needed to provide inputs for
-downstream recipes
-
 ## Installation
 Install via pip:
 ```shell script
@@ -80,3 +65,17 @@ python3 labfile.py brew test
 
 ## License
 alkymi is licensed under The MIT License as found in the LICENSE.md file
+
+## Upcoming Features
+The following features are being considered for future implementation:
+* Type annotations propagated from bound functions to recipes
+* Support for call/type checking all recipes (e.g. by adding a `check` command to `Lab`)
+* Cache maintenance functionality
+
+## Known Issues
+* alkymi currently doesn't check custom objects for altered external files when computing cleanliness (e.g. `MyClass`
+has a `self._some_path` that points to a file somewhere outside alkymi's internal cache)
+* `alk.foreach()` currently only supports enumerable inputs of type `List` or `Dict`
+* Recipes marked `transient` will always be dirty, and thus always require reevaluation. This functionality should be
+replaced by a proper means of creating recipes that don't cache outputs, but only run when needed to provide inputs for
+downstream recipes

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -285,7 +285,7 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
     :param graph: The graph to use for evaluation
     :param statuses: The statuses of the recipes contained in the graph - used to skip evaluation if unnecessary
     :param jobs: The number of jobs to use for evaluating the recipe in parallel, 1 job corresponds to no parallelism,
-    zero or negative values will cause alkymi to use the system's default number of jobs
+                 zero or negative values will cause alkymi to use the system's default number of jobs
     :return: The output(s) and checksum(s) of the evaluated recipe
     """
     # Create the executor to use for evaluating recipes
@@ -359,7 +359,7 @@ def brew(recipe: Recipe[R], *, jobs: int) -> R:
 
     :param recipe: The Recipe to evaluate
     :param jobs: The number of jobs to use for evaluating the recipe in parallel, 1 job corresponds to no parallelism,
-    zero or negative values will cause alkymi to use the system's default number of jobs
+                 zero or negative values will cause alkymi to use the system's default number of jobs
     :return: The outputs of the Recipe (which correspond to the outputs of the bound function)
     """
     graph = create_graph(recipe)

--- a/alkymi/foreach_recipe.py
+++ b/alkymi/foreach_recipe.py
@@ -139,7 +139,7 @@ class ForeachRecipe(Recipe[R]):
     def outputs_valid(self) -> bool:
         """
         Check whether an output is still valid - this is currently only used to check files that may have been deleted
-        or altered outside of alkymi's cache. If no outputs have been produced yet, True will be returned.
+        or altered outside alkymi's cache. If no outputs have been produced yet, True will be returned.
 
         :return: Whether all outputs are still valid
         """
@@ -154,6 +154,15 @@ class ForeachRecipe(Recipe[R]):
 
     def set_current_result(self, evaluated: MappedInputs, outputs: MappedOutputs, mapped_inputs_checksum: Optional[str],
                            other_input_checksums: Tuple[Optional[str], ...], completed: bool) -> None:
+        """
+        Stores the provided results in the recipe and caches them to disk if applicable
+
+        :param evaluated: The inputs that were used to generate the provided outputs
+        :param outputs: The outputs to store in this recipe
+        :param mapped_inputs_checksum: The checksum of all mapped inputs
+        :param other_input_checksums: The checksums of other (non-mapped) inputs
+        :param completed: Bool indicating whether all mapped inputs have been processed
+        """
         self.mapped_inputs = evaluated
         self._mapped_outputs = outputs
         self._mapped_outputs_checksum = checksums.checksum(outputs)

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -60,7 +60,7 @@ class Lab:
 
         :param target_recipe: The recipe to evaluate, as a reference ot by name
         :param jobs: The number of jobs to use for evaluating this recipe in parallel, defaults to 1 (no parallelism),
-        zero or negative values will cause alkymi to use the system's default number of jobs
+                     zero or negative values will cause alkymi to use the system's default number of jobs
         :return: The output of the evaluated recipe
         """
         if isinstance(target_recipe, str):

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -54,23 +54,25 @@ class Lab:
         """
         self._args[arg.name] = arg
 
-    def brew(self, target_recipe: Union[Recipe, str]) -> Any:
+    def brew(self, target_recipe: Union[Recipe, str], *, jobs=1) -> Any:
         """
         Brew (evaluate) a target recipe defined by its reference or name, and return the results
 
         :param target_recipe: The recipe to evaluate, as a reference ot by name
+        :param jobs: The number of jobs to use for evaluating this recipe in parallel, defaults to 1 (no parallelism),
+        zero or negative values will cause alkymi to use the system's default number of jobs
         :return: The output of the evaluated recipe
         """
         if isinstance(target_recipe, str):
             # Try to match name
             for recipe in self._recipes:
                 if recipe.name == target_recipe:
-                    return recipe.brew()
+                    return recipe.brew(jobs=jobs)
             raise ValueError("Unknown recipe: {}".format(target_recipe))
         else:
             # Match recipe directly
             if target_recipe in self._recipes:
-                return target_recipe.brew()
+                return target_recipe.brew(jobs=jobs)
             raise ValueError("Unknown recipe: {}".format(target_recipe.name))
 
     @property
@@ -159,6 +161,7 @@ class Lab:
         brew_parser = subparsers.add_parser('brew', help='Brew the selected recipe')
         brew_parser.add_argument('recipe', choices=[recipe.name for recipe in self._recipes], nargs="+",
                                  help='Recipe(s) to brew')
+        brew_parser.add_argument("-j", "--jobs", type=int, default=1)
         self._add_user_args_(brew_parser)
 
         parsed_args = parser.parse_args(args)
@@ -178,7 +181,7 @@ class Lab:
             print(self, file=stream)
         elif parsed_args.subparser_name == 'brew':
             for recipe in parsed_args.recipe:
-                self.brew(recipe)
+                self.brew(recipe, jobs=parsed_args.jobs)
         else:
             # No recognized command provided - print help
             parser.print_help(file=stream)

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -161,7 +161,8 @@ class Lab:
         brew_parser = subparsers.add_parser('brew', help='Brew the selected recipe')
         brew_parser.add_argument('recipe', choices=[recipe.name for recipe in self._recipes], nargs="+",
                                  help='Recipe(s) to brew')
-        brew_parser.add_argument("-j", "--jobs", type=int, default=1)
+        brew_parser.add_argument("-j", "--jobs", type=int, default=1,
+                                 help="Use N jobs to evaluate the recipe, more than 1 job will parallelize evaluation")
         self._add_user_args_(brew_parser)
 
         parsed_args = parser.parse_args(args)

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 from pathlib import Path
-from typing import Iterable, Callable, List, Optional, Tuple, Any, TypeVar, Generic, cast
+from typing import Iterable, Callable, List, Optional, Tuple, TypeVar, Generic, cast
 
 from . import checksums, serialization
 from .config import CacheType, AlkymiConfig
@@ -80,17 +80,7 @@ class Recipe(Generic[R]):
         """
         return self._func(*args)
 
-    def invoke(self, inputs: Tuple[Any, ...], input_checksums: Tuple[Optional[str], ...]) -> None:
-        """
-        Evaluate this Recipe using the provided inputs. This will call the bound function on the inputs. If the result
-        is already cached, that result will be used instead (the checksum is used to check this). Only the immediately
-        previous invoke call will be cached
-
-        :param inputs: The inputs provided by the ingredients (dependencies) of this Recipe
-        :param input_checksums: The (possibly new) input checksum to use for checking cleanliness
-        """
-        log.debug('Invoking recipe: {}'.format(self.name))
-        outputs = self(*inputs)
+    def set_result(self, outputs: R, input_checksums: Tuple[Optional[str], ...]) -> None:
         self.outputs = outputs
         self._input_checksums = input_checksums
         self._last_function_hash = self.function_hash

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -98,7 +98,7 @@ class Recipe(Generic[R]):
         dependencies to produce the outputs of this Recipe
 
         :param jobs: The number of jobs to use for evaluating this recipe in parallel, defaults to 1 (no parallelism),
-        zero or negative values will cause alkymi to use the system's default number of jobs
+                     zero or negative values will cause alkymi to use the system's default number of jobs
         :return: The outputs of this Recipe (which correspond to the outputs of the bound function)
         """
         # Lazy import to avoid circular imports

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -96,16 +96,18 @@ class Recipe(Generic[R]):
         self._last_function_hash = self.function_hash
         self._save_state()
 
-    def brew(self) -> R:
+    def brew(self, *, jobs: int = 1) -> R:
         """
         Evaluate this Recipe and all dependent inputs - this will build the computational graph and execute any needed
         dependencies to produce the outputs of this Recipe
 
+        :param jobs: The number of jobs to use for evaluating this recipe in parallel, defaults to 1 (no parallelism),
+        zero or negative values will cause alkymi to use the system's default number of jobs
         :return: The outputs of this Recipe (which correspond to the outputs of the bound function)
         """
         # Lazy import to avoid circular imports
         from .core import brew
-        return brew(self)
+        return brew(self, jobs=jobs)
 
     def status(self) -> Status:
         """

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -81,6 +81,12 @@ class Recipe(Generic[R]):
         return self._func(*args)
 
     def set_result(self, outputs: R, input_checksums: Tuple[Optional[str], ...]) -> None:
+        """
+        Stores the provided result in the recipe and caches it to disk if applicable
+
+        :param outputs: The outputs to store in the recipe
+        :param input_checksums: The checksums of the inputs that were used to calculate the outputs
+        """
         self.outputs = outputs
         self._input_checksums = input_checksums
         self._last_function_hash = self.function_hash

--- a/alkymi/version.py
+++ b/alkymi/version.py
@@ -1,3 +1,3 @@
 # Define the alkymi version as a tuple and a string
-VERSION = (0, 0, 7)
+VERSION = (0, 1, 0)
 __version__ = ".".join(str(c) for c in VERSION)

--- a/docs/source/advanced/execution.rst
+++ b/docs/source/advanced/execution.rst
@@ -22,7 +22,6 @@ the graph. The status can take on the following states:
   (see :ref:`checksums_external_files`)
 * ``BoundFunctionChanged``: The function referenced by the recipe has changed
 * ``CustomDirty``: The recipe has been marked dirty through a custom cleanliness function
-* ``MappedInputsDirty``: One or more mapped inputs to the recipe have changed (see :ref:`sequences`)
 
 Throughout the documentation, "clean" will be used to refer to the ``Ok`` status, in which everything is up-to-date, and
 no work needs to be done; and "dirty", which is all the status states that require some sort of (re)evaluation.
@@ -60,6 +59,13 @@ evaluated, the outputs are returned from the ``.brew()`` call to the caller.
 Note that when a sequence of similar values (e.g. a list of strings) needs to have a function applied to each of them
 (similar to Python's built-in ``map`` function), alkymi can perform partial evaluation and caching of the results (see
 :ref:`sequences`)
+
+.. rubric:: Parallel Execution
+
+When calling ``.brew()``, the ``jobs`` argument can be used to specify a number of threads to parallelize the evaluation
+across (the default is 1 - i.e. single threaded execution). When using multiple threads, alkymi will automatically run
+bound functions as soon as their inputs become available.
+
 
 .. _custom_cleanliness:
 .. rubric:: Custom Cleanliness Functions

--- a/docs/source/advanced/sequences.rst
+++ b/docs/source/advanced/sequences.rst
@@ -42,3 +42,9 @@ in future releases):
 Note that using ``foreach()`` still shares all the functionality of the regular ``recipe()`` decorator - alkymi will
 still check whether your bound function or dependencies have changed, and mark the recipe dirty in that case
 (see :ref:`execution`) for an exhaustive list of up-to-date checks.
+
+
+.. rubric:: Parallel Execution
+
+If parallel execution is enabled (see :ref:`execution`), alkymi will apply the bound function to each item in parallel.
+Note that the order of execution is not guaranteed in this case.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -48,7 +48,7 @@ Built-in Recipes
 
 Core
 ----
-.. automodule:: alkymi.alkymi
+.. automodule:: alkymi.core
     :members:
 
 .. _alkymi_config:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ from alkymi import __version__
 # -- Project information -----------------------------------------------------
 
 project = 'alkymi'
-copyright = '2021, Mathias Bøgh Stokholm'
+copyright = '2023, Mathias Bøgh Stokholm'
 author = 'Mathias Bøgh Stokholm'
 
 # The short X.Y version

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     url="https://github.com/MathiasStokholm/alkymi",
     packages=["alkymi"],
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Environment :: Console",
         "Natural Language :: English",
@@ -52,7 +52,7 @@ setuptools.setup(
     extras_require={
         "xxhash": ["xxhash>=2.0.0"]
     },
-    package_data = {
+    package_data={
         "alkymi": ["py.typed"],
     },
 )

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -3,6 +3,8 @@ import logging
 from pathlib import Path
 from typing import List
 
+import pytest
+
 from alkymi import AlkymiConfig
 import alkymi as alk
 from alkymi.core import Status
@@ -69,6 +71,8 @@ def test_foreach_caching(caplog, tmpdir):
     """
     Test that ForeachRecipe is able to handle failures, reloading, etc.
     """
+    pytest.skip("Currently broken after switching to async execution")
+
     tmpdir = Path(str(tmpdir))
     caplog.set_level(logging.DEBUG)
     AlkymiConfig.get().cache = True

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -3,8 +3,6 @@ import logging
 from pathlib import Path
 from typing import List
 
-import pytest
-
 from alkymi import AlkymiConfig
 import alkymi as alk
 from alkymi.core import Status
@@ -71,8 +69,6 @@ def test_foreach_caching(caplog, tmpdir):
     """
     Test that ForeachRecipe is able to handle failures, reloading, etc.
     """
-    pytest.skip("Currently broken after switching to async execution")
-
     tmpdir = Path(str(tmpdir))
     caplog.set_level(logging.DEBUG)
     AlkymiConfig.get().cache = True

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -70,15 +70,16 @@ def test_create_graph() -> None:
     assert graph.has_successor(c, root)
 
 
-def test_parallel_threading() -> None:
+def test_sequential() -> None:
     """
-    Test that recipes can execute in parallel
+    Test that recipes can execute sequentially (without parallelism)
     """
     AlkymiConfig.get().cache = False
 
     @alk.recipe()
     def a() -> Tuple[float, int]:
         thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
         print(f"Executing a on {thread_idx}")
         time.sleep(0.01)
         called = time.perf_counter()
@@ -87,6 +88,7 @@ def test_parallel_threading() -> None:
     @alk.recipe()
     def b() -> Tuple[float, int]:
         thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
         print(f"Executing b on {thread_idx}")
         time.sleep(0.01)
         called = time.perf_counter()
@@ -95,12 +97,55 @@ def test_parallel_threading() -> None:
     @alk.recipe()
     def ab(a, b) -> Tuple[Tuple[float, int], ...]:
         thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
+        print(f"Executing ab on {thread_idx}")
+        called = time.perf_counter()
+        return a, b, (called, thread_idx)
+
+    # 'a' and 'b' should not have executed in parallel
+    results_a, results_b, results_ab = ab.brew(jobs=1)
+    assert results_a[0] != pytest.approx(results_b[0])
+    assert results_a != pytest.approx(results_ab[0])
+
+    # 'a' and 'b' should have executed on the same thread
+    assert results_a[1] == results_b[1]
+
+
+@pytest.mark.parametrize("jobs", (0, 3, 5, 8, -1))
+def test_parallel_threading(jobs: int) -> None:
+    """
+    Test that recipes can execute in parallel
+    """
+    AlkymiConfig.get().cache = False
+
+    @alk.recipe()
+    def a() -> Tuple[float, int]:
+        thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
+        print(f"Executing a on {thread_idx}")
+        time.sleep(0.01)
+        called = time.perf_counter()
+        return called, thread_idx
+
+    @alk.recipe()
+    def b() -> Tuple[float, int]:
+        thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
+        print(f"Executing b on {thread_idx}")
+        time.sleep(0.01)
+        called = time.perf_counter()
+        return called, thread_idx
+
+    @alk.recipe()
+    def ab(a, b) -> Tuple[Tuple[float, int], ...]:
+        thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
         print(f"Executing ab on {thread_idx}")
         called = time.perf_counter()
         return a, b, (called, thread_idx)
 
     # 'a' and 'b' should have executed in parallel
-    results_a, results_b, results_ab = ab.brew()
+    results_a, results_b, results_ab = ab.brew(jobs=jobs)
     assert results_a[0] == pytest.approx(results_b[0])
     assert results_a != pytest.approx(results_ab[0])
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -111,43 +111,46 @@ def test_sequential() -> None:
     assert results_a[1] == results_b[1]
 
 
+# Barrier used by test_parallel_threading - has to be global to avoid being captured in checksum (cannot be pickled)
+barrier = threading.Barrier(parties=2, timeout=1)
+
+
 @pytest.mark.parametrize("jobs", (0, 3, 5, 8, -1))
 def test_parallel_threading(jobs: int) -> None:
     """
-    Test that recipes can execute in parallel
+    Test that recipes can execute in parallel by waiting on a barrier with N=2 from two recipes - the waits will time
+    out if less than two threads wait on the barrier in parallel
     """
     AlkymiConfig.get().cache = False
+    barrier.reset()
 
     @alk.recipe()
-    def a() -> Tuple[float, int]:
+    def a() -> int:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing a on {thread_idx}")
-        time.sleep(0.02)
-        called = time.perf_counter()
-        return called, thread_idx
+        barrier.wait()
+        return thread_idx
 
     @alk.recipe()
-    def b() -> Tuple[float, int]:
+    def b() -> int:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing b on {thread_idx}")
-        time.sleep(0.02)
-        called = time.perf_counter()
-        return called, thread_idx
+        barrier.wait()
+        return thread_idx
 
     @alk.recipe()
-    def ab(a, b) -> Tuple[Tuple[float, int], ...]:
+    def ab(a: int, b: int) -> Tuple[int, ...]:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing ab on {thread_idx}")
-        called = time.perf_counter()
-        return a, b, (called, thread_idx)
+        return a, b, thread_idx
 
     # 'a' and 'b' should have executed in parallel
-    results_a, results_b, results_ab = ab.brew(jobs=jobs)
-    assert results_a[0] == pytest.approx(results_b[0], abs=0.01)
-    assert results_a != pytest.approx(results_ab[0])
-
-    # 'a' and 'b' should have executed on different threads
-    assert results_a[1] != results_b[1]
+    try:
+        thread_idx_a, thread_idx_b, _ = ab.brew(jobs=jobs)
+        # 'a' and 'b' should have executed on different threads
+        assert thread_idx_a != thread_idx_b
+    except threading.BrokenBarrierError:
+        pytest.fail("a and b did not execute in parallel")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
-import os
 import threading
 import time
 from typing import List, Tuple
 
 import pytest
 
-from alkymi import AlkymiConfig
 import alkymi as alk
+from alkymi import AlkymiConfig
 
 
 def test_create_graph() -> None:
@@ -99,49 +98,6 @@ def test_parallel_threading() -> None:
         print(f"Executing ab on {thread_idx}")
         called = time.perf_counter()
         return a, b, (called, thread_idx)
-
-    # 'a' and 'b' should have executed in parallel
-    results_a, results_b, results_ab = ab.brew()
-    assert results_a[0] == pytest.approx(results_b[0])
-    assert results_a != pytest.approx(results_ab[0])
-
-    # 'a' and 'b' should have executed on different threads
-    assert results_a[1] != results_b[1]
-
-
-def a_process() -> Tuple[float, int]:
-    process_idx = os.getpid()
-    print(f"Executing a on {process_idx}")
-    time.sleep(0.01)
-    called = time.perf_counter()
-    return called, process_idx
-
-
-def b_process() -> Tuple[float, int]:
-    process_idx = os.getpid()
-    print(f"Executing b on {process_idx}")
-    time.sleep(0.01)
-    called = time.perf_counter()
-    return called, process_idx
-
-
-def ab_process(a, b) -> Tuple[Tuple[float, int], ...]:
-    process_idx = os.getpid()
-    print(f"Executing ab on {process_idx}")
-    called = time.perf_counter()
-    return a, b, (called, process_idx)
-
-
-def test_parallel_multiprocess() -> None:
-    """
-    Test that recipes can execute in parallel using multiple processes
-    """
-    pytest.skip("multiprocessing doesnt work yet")
-    AlkymiConfig.get().cache = False
-
-    a = alk.recipe()(a_process)
-    b = alk.recipe()(b_process)
-    ab = alk.recipe(ingredients=(a, b))(ab_process)
 
     # 'a' and 'b' should have executed in parallel
     results_a, results_b, results_ab = ab.brew()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -81,7 +81,7 @@ def test_sequential() -> None:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing a on {thread_idx}")
-        time.sleep(0.01)
+        time.sleep(0.02)
         called = time.perf_counter()
         return called, thread_idx
 
@@ -90,7 +90,7 @@ def test_sequential() -> None:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing b on {thread_idx}")
-        time.sleep(0.01)
+        time.sleep(0.02)
         called = time.perf_counter()
         return called, thread_idx
 
@@ -104,7 +104,7 @@ def test_sequential() -> None:
 
     # 'a' and 'b' should not have executed in parallel
     results_a, results_b, results_ab = ab.brew(jobs=1)
-    assert results_a[0] != pytest.approx(results_b[0])
+    assert results_a[0] != pytest.approx(results_b[0], abs=0.01)
     assert results_a != pytest.approx(results_ab[0])
 
     # 'a' and 'b' should have executed on the same thread
@@ -123,7 +123,7 @@ def test_parallel_threading(jobs: int) -> None:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing a on {thread_idx}")
-        time.sleep(0.01)
+        time.sleep(0.02)
         called = time.perf_counter()
         return called, thread_idx
 
@@ -132,7 +132,7 @@ def test_parallel_threading(jobs: int) -> None:
         thread_idx = threading.current_thread().ident
         assert thread_idx is not None
         print(f"Executing b on {thread_idx}")
-        time.sleep(0.01)
+        time.sleep(0.02)
         called = time.perf_counter()
         return called, thread_idx
 
@@ -146,7 +146,7 @@ def test_parallel_threading(jobs: int) -> None:
 
     # 'a' and 'b' should have executed in parallel
     results_a, results_b, results_ab = ab.brew(jobs=jobs)
-    assert results_a[0] == pytest.approx(results_b[0])
+    assert results_a[0] == pytest.approx(results_b[0], abs=0.01)
     assert results_a != pytest.approx(results_ab[0])
 
     # 'a' and 'b' should have executed on different threads


### PR DESCRIPTION
### Added
- Added support for parallel execution - the `brew()` function now takes a `jobs` parameter that controls
parallelization of the recipe evaluation.
- Added support for parallel execution to the `Lab` CLI - use `--jobs` or `-j` when calling `brew` to run pipeline in
parallel

### Changed
- The `invoke` and `invoke_foreach` functions have been moved from `recipe.py` and `foreach_recipe.py` into `core.py`
to allow more control over the execution flow.