### PR TITLE
Bugfix for foreach deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No unreleased changes yet
+### Changed
+- Rewrote parallel execution to only run bound functions in parallel, but use asyncio for the main execution logic
+
+### Fixed
+- Fixed a bug where a deadlock could occur when evaluating a number of `ForeachRecipes` with the same number of jobs
+- Fixed a bug where a certain graph configuration could prevent parallelization from happening correctly
 
 ## [0.1.0] - 2023-03-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 Alkymi is a pure Python (3.6+) library for describing and executing tasks and pipelines with built-in caching and
 conditional evaluation based on checksums.
 
-Alkymi is easy to install, simple to use, and has no dependencies outside of Python's standard library. The code is
-cross-platform, and allows you to write your pipelines once and deploy to multiple operating systems (tested on Linux,
-Windows and Mac).
+Alkymi is easy to install, simple to use, and has very few dependencies outside of Python's standard library. The code
+is cross-platform, and allows you to write your pipelines once and deploy to multiple operating systems (tested on
+Linux, Windows and Mac).
 
 Documentation, including a quickstart guide, is provided [here](https://alkymi.readthedocs.io/en/latest/).
 

--- a/labfile.py
+++ b/labfile.py
@@ -28,7 +28,10 @@ def test(test_files: List[Path]) -> None:
 
     :param test_files: The pytest files to execute
     """
-    result = pytest.main(args=[str(file) for file in test_files])
+    # Run pytest in a separate thread to avoid asyncio recursion issues
+    from concurrent.futures import ThreadPoolExecutor
+    executor = ThreadPoolExecutor(max_workers=1)
+    result = executor.submit(pytest.main, args=[str(file) for file in test_files]).result()
     if result != pytest.ExitCode.OK:
         exit(1)
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -158,3 +158,42 @@ def test_parallel_threading(jobs: int) -> None:
         assert thread_idx_a != thread_idx_b
     except threading.BrokenBarrierError:
         pytest.fail("a and b did not execute in parallel")
+
+
+# Barrier used by test_parallel_foreach - has to be global to avoid being captured in checksum (cannot be pickled)
+foreach_barrier = threading.Barrier(parties=10, timeout=1)
+
+
+def test_parallel_foreach() -> None:
+    """
+    Test that execution of ForeachRecipe happens correctly in parallel by requiring N threads to block on the barrier
+    from the bound function
+    """
+    jobs = foreach_barrier.parties
+    AlkymiConfig.get().cache = False
+    foreach_barrier.reset()
+
+    # Run a number of jobs in parallel that matches the barrier wait count
+    input_ids = alk.recipes.arg(list(range(0, jobs)), name="input_ids")
+
+    @alk.foreach(input_ids)
+    def synchronize(input_id: int) -> Tuple[int, int]:
+        thread_idx = threading.current_thread().ident
+        assert thread_idx is not None
+        foreach_barrier.wait()
+        return input_id, thread_idx
+
+    try:
+        # Gather results
+        id_to_thread_map = {
+            result[0]: result[1]  # type: ignore
+            for result in synchronize.brew(jobs=jobs)
+        }
+
+        # Check that all calls happened on unique threads
+        assert len(id_to_thread_map.values()) == len(set(id_to_thread_map.values()))
+
+        # Check that all IDs were processed in the correct order
+        assert list(id_to_thread_map.keys()) == input_ids.brew()
+    except threading.BrokenBarrierError:
+        pytest.fail("ForeachRecipe did not execute bound functions in parallel")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -107,15 +107,19 @@ def test_sequential() -> None:
     assert results_a[0] != pytest.approx(results_b[0], abs=0.01)
     assert results_a != pytest.approx(results_ab[0])
 
-    # 'a' and 'b' should have executed on the same thread
-    assert results_a[1] == results_b[1]
+    # 'a', 'b' and 'ab' should have executed on the current (main) thread
+    main_thread_idx = threading.current_thread().ident
+    assert main_thread_idx is not None
+    assert results_a[1] == main_thread_idx
+    assert results_b[1] == main_thread_idx
+    assert results_ab[1] == main_thread_idx
 
 
 # Barrier used by test_parallel_threading - has to be global to avoid being captured in checksum (cannot be pickled)
 barrier = threading.Barrier(parties=2, timeout=1)
 
 
-@pytest.mark.parametrize("jobs", (0, 3, 5, 8, -1))
+@pytest.mark.parametrize("jobs", (0, 2, 5, 8, -1))
 def test_parallel_threading(jobs: int) -> None:
     """
     Test that recipes can execute in parallel by waiting on a barrier with N=2 from two recipes - the waits will time


### PR DESCRIPTION
This PR adds the following changes

### Changed
- Rewrote parallel execution to only run bound functions in parallel, but use asyncio for the main execution logic

### Fixed
- Fixed a bug where a deadlock could occur when evaluating a number of `ForeachRecipes` with the same number of jobs
- Fixed a bug where a certain graph configuration could prevent parallelization from happening correctly