### PR TITLE
Various bugfixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)  
 
 ## [0.2.1] - 2023-04-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)  
+- Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
+- Fixed a bug where the terminal cursor would disappear if an exception was thrown during execution
+- Fixed a bug where the terminal cursor would disappear if a `Lab` call to `brew` was terminated using ctrl-c
 
 ## [0.2.1] - 2023-04-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `stderr` is now streamed by default when using the `utils.call()` utility function [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
+
 ### Fixed
 - Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
 - Fixed a bug where the terminal cursor would disappear if an exception was thrown during execution

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -386,11 +386,14 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
 
     # Check if the event loop is already running - if this is the case, execution must be pushed to a new thread to
     # avoid crashing due to the already running event loop
-    output, checksum = utils.run_on_thread(_setup_and_execute) if utils.check_current_thread_has_running_event_loop() \
-        else _setup_and_execute()
+    try:
+        output, checksum = utils.run_on_thread(_setup_and_execute) if utils.check_current_thread_has_running_event_loop() \
+            else _setup_and_execute()
+    finally:
+        # Ensure that the progress is always stopped (to return the cursor correctly to the terminal)
+        if progress is not None:
+            progress.stop()
 
-    if progress is not None:
-        progress.stop()
     return output, checksum
 
 

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -387,8 +387,8 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
     # Check if the event loop is already running - if this is the case, execution must be pushed to a new thread to
     # avoid crashing due to the already running event loop
     try:
-        output, checksum = utils.run_on_thread(_setup_and_execute) if utils.check_current_thread_has_running_event_loop() \
-            else _setup_and_execute()
+        output, checksum = utils.run_on_thread(
+            _setup_and_execute) if utils.check_current_thread_has_running_event_loop() else _setup_and_execute()
     finally:
         # Ensure that the progress is always stopped (to return the cursor correctly to the terminal)
         if progress is not None:

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -5,6 +5,7 @@ from typing import Dict, Union, Any, List, Optional
 from typing import Iterable, TextIO
 
 from rich import console
+from rich.control import Control
 
 from .core import Status, compute_recipe_status, create_graph
 from .logging import log
@@ -76,7 +77,9 @@ class Lab:
             try:
                 return _recipe.brew(jobs=jobs, progress_type=progress_type)
             except KeyboardInterrupt:
-                self._console.print("[bold red]Interrupted by user")
+                # Signal that execution was interrupted by the user and return cursor to normal state
+                self._console.print("\n[bold red]Interrupted by user")
+                self._console.control(Control.show_cursor(True))
                 sys.exit(1)
 
         if isinstance(target_recipe, str):

--- a/alkymi/progress.py
+++ b/alkymi/progress.py
@@ -29,7 +29,7 @@ class FancyProgress(rich.progress.Progress):
         # Define the columns to use for progress table
         super().__init__(TextColumn("[deep_sky_blue2]{task.description}"),
                          BarColumn(),
-                         TextColumn("{task.completed}/{task.total} ({task.percentage}%)"),
+                         TextColumn("{task.completed}/{task.total} ({task.percentage:>3.0f}%)"),
                          TextColumn("•"),
                          TimeElapsedColumn(),
                          console=self._console, redirect_stdout=True, redirect_stderr=True)

--- a/alkymi/utils.py
+++ b/alkymi/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import fcntl
 import os
 import subprocess
 import sys
@@ -42,11 +41,9 @@ def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr,
     # If running either stdout or stderr live, set the streams to non-blocking mode to ensure that we don't block
     # when trying to read from either of them
     if live_stdout:
-        fl = fcntl.fcntl(proc.stdout, fcntl.F_GETFL)
-        fcntl.fcntl(proc.stdout, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        os.set_blocking(proc.stdout.fileno(), False)
     if live_stderr:
-        fl = fcntl.fcntl(proc.stderr, fcntl.F_GETFL)
-        fcntl.fcntl(proc.stderr, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+        os.set_blocking(proc.stderr.fileno(), False)
 
     stdout: str = ""
     stderr: str = ""

--- a/alkymi/utils.py
+++ b/alkymi/utils.py
@@ -1,7 +1,10 @@
 import asyncio
+import fcntl
+import os
 import subprocess
 import sys
 import threading
+import time
 from typing import List, TextIO, Optional, TypeVar, Callable
 
 from .logging import log
@@ -14,7 +17,7 @@ def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr,
     log)
 
     :param args: The arguments representing the command to run, e.g. ["echo", "test"]
-    :param echo_error_to_stream: A stream to which to echo the call's stderr on a non-zero exit code
+    :param echo_error_to_stream: A stream to which to echo the call's stderr while the command is executing
     :param echo_output_to_stream: A stream to which to echo the call's stdout while the command is executing
     :return: The result of the execution as a subprocess.CompletedProcess instance
     """
@@ -22,42 +25,72 @@ def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr,
     if echo_output_to_stream is not None and getattr(echo_output_to_stream, "name", None) == sys.stdout.name:
         echo_output_to_stream = sys.stdout
 
+    # If running through a Lab CLI, sys.stderr may have been redirected
+    if echo_error_to_stream is not None and getattr(echo_error_to_stream, "name", None) == sys.stderr.name:
+        echo_error_to_stream = sys.stderr
+
+    live_stdout = echo_output_to_stream is not None
+    live_stderr = echo_error_to_stream is not None
+
     # Buffer one line at a time if echoing live, otherwise just use the default
-    buffer_size = 1 if echo_output_to_stream is not None else -1
+    buffer_size = 1 if (live_stdout or live_stderr) else -1
     proc = subprocess.Popen(args, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             bufsize=buffer_size)
+
+    # If running either stdout or stderr live, set the streams to non-blocking mode to ensure that we don't block
+    # when trying to read from either of them
+    if live_stdout:
+        fl = fcntl.fcntl(proc.stdout, fcntl.F_GETFL)
+        fcntl.fcntl(proc.stdout, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+    if live_stderr:
+        fl = fcntl.fcntl(proc.stderr, fcntl.F_GETFL)
+        fcntl.fcntl(proc.stderr, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
     # Since we set these to PIPE, these should never be None
     assert proc.stdout is not None
     assert proc.stderr is not None
 
     stdout: str = ""
-    if echo_output_to_stream is not None:
+    stderr: str = ""
+    if live_stdout or live_stderr:
         # Print each line to the stream as it arrives
         while proc.poll() is None:
-            line = proc.stdout.readline()
-            echo_output_to_stream.write(line)
-            stdout += line
+            if live_stdout:
+                line = proc.stdout.readline()
+                echo_output_to_stream.write(line)
+                stdout += line
+            if live_stderr:
+                line = proc.stderr.readline()
+                echo_error_to_stream.write(line)
+                stderr += line
 
-        # Program has finished executing, check if any part of stdout still needs to be piped
-        line = proc.stdout.readline()
-        if line:
-            echo_output_to_stream.write(line)
-            stdout += line
+            # Sleep for a tiny bit to ensure that the non-blocking calls don't eat a ton of CPU
+            time.sleep(0.001)
+
+        # Program has finished executing, check if any part of stdout or stderr still needs to be piped
+        if live_stdout:
+            line = proc.stdout.readline()
+            if line:
+                echo_output_to_stream.write(line)
+                stdout += line
+        # if live_stderr:
+        #     line = proc.stderr.readline()
+        #     if line:
+        #         echo_error_to_stream.write(line)
+        #         stderr += line
     else:
         # Otherwise, simply wait for the command to finish and then grab stdout
         proc.wait()
-        stdout = proc.stdout.read()
 
-    stderr = proc.stderr.read()
+    # If not running live, read everything in one go
+    if not live_stdout:
+        stdout = proc.stdout.read()
+    if not live_stderr:
+        stderr = proc.stderr.read()
 
     # Send to alkymi log
     log.debug(stdout)
     log.debug(stderr)
-
-    # Always forward error messages to stderr if needed
-    if echo_error_to_stream is not None and proc.returncode != 0:
-        echo_error_to_stream.write(stderr)
 
     # Raise an error on failure
     if proc.returncode != 0:

--- a/alkymi/utils.py
+++ b/alkymi/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import threading
 import time
+import platform
 from typing import List, TextIO, Optional, TypeVar, Callable
 
 
@@ -40,10 +41,11 @@ def call(args: List[str], echo_error_to_stream: Optional[TextIO] = sys.stderr,
 
     # If running either stdout or stderr live, set the streams to non-blocking mode to ensure that we don't block
     # when trying to read from either of them
-    if live_stdout:
-        os.set_blocking(proc.stdout.fileno(), False)
-    if live_stderr:
-        os.set_blocking(proc.stderr.fileno(), False)
+    if platform.system() != "Windows":
+        if live_stdout:
+            os.set_blocking(proc.stdout.fileno(), False)
+        if live_stderr:
+            os.set_blocking(proc.stderr.fileno(), False)
 
     stdout: str = ""
     stderr: str = ""
@@ -103,10 +105,10 @@ def run_on_thread(func: Callable[..., T]) -> T:
 
     # Mutable object used to store result
     result: List[T] = []
-    ex = []
+    ex: List[Exception] = []
 
     def _call_and_set_result():
-        nonlocal result
+        nonlocal result, ex
         try:
             result.append(func())
         except Exception as e:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.7
 warn_unused_configs = True
+exclude = .venv
 
 [mypy-numpy]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx>=2.0
 rich>=10.7
+markdown-it-py<3.0.0  # Lock, since v3.0 doesn't support Python 3.7 (mypy type check fails)


### PR DESCRIPTION
### Changed
- `stderr` is now streamed by default when using the `utils.call()` utility function [#42](https://github.com/MathiasStokholm/alkymi/issues/42)

### Fixed
- Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
- Fixed a bug where the terminal cursor would disappear if an exception was thrown during execution
- Fixed a bug where the terminal cursor would disappear if a `Lab` call to `brew` was terminated using ctrl-c