### PR TITLE
Fixed caching of recipes with no return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
 - Fixed a bug where the terminal cursor would disappear if an exception was thrown during execution
 - Fixed a bug where the terminal cursor would disappear if a `Lab` call to `brew` was terminated using ctrl-c
+- Fixed a bug where recipes returning `None` (no return value) would not be correctly cached on subsequent runs
 
 ## [0.2.1] - 2023-04-27
 ### Fixed

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -246,10 +246,8 @@ class Recipe(Generic[R]):
         :param old_state: The old cached state to restore
         """
         log.debug("Restoring {} from dict".format(self._name))
-        if old_state["input_checksums"] is not None:
-            self._input_checksums = tuple(old_state["input_checksums"])
-        if old_state["outputs"] is not None and old_state["output_checksum"] is not None:
-            self._outputs = CachedOutput(None, old_state["output_checksum"], old_state["outputs"])
+        self._input_checksums = tuple(old_state["input_checksums"])
+        self._outputs = CachedOutput(None, old_state["output_checksum"], old_state["outputs"])
         self._last_function_hash = cast(str, old_state["last_function_hash"])
 
     def __repr__(self) -> str:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -49,15 +49,20 @@ def test_caching_no_return_value(caplog, tmpdir):
     AlkymiConfig.get().cache = True
     AlkymiConfig.get().cache_path = tmpdir
 
-    @alk.recipe()
-    def no_return_value() -> None:
+    def no_return_value_func() -> None:
         some_state = "This is a debug statement from test_caching_no_return_value()"
         alk.log.debug(some_state)  # Simulate non-pure function
 
+    # Check that brewing the recipe results in an Ok status (cached in-memory)
+    no_return_value = alk.recipe()(no_return_value_func)
     assert no_return_value.status() == Status.NotEvaluatedYet
     no_return_value.brew()
     assert no_return_value.status() == Status.Ok
-    assert (tmpdir / Recipe.CACHE_DIRECTORY_NAME / "tests" / "no_return_value").is_dir()
+    assert (tmpdir / Recipe.CACHE_DIRECTORY_NAME / "tests" / "no_return_value_func").is_dir()
+
+    # Re-create recipe to check that disk caching also results in an Ok status
+    no_return_value_2 = alk.recipe()(no_return_value_func)
+    assert no_return_value_2.status() == Status.Ok
 
 
 # We use these globals to avoid altering the hashes of bound functions when these change

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -41,7 +41,7 @@ def test_serialize_deserialize_items(tmpdir):
     tmpdir = Path(str(tmpdir))
 
     json_str = "{'test': 13 []''{}!!"
-    items = (Path("test"), "test2", 42, 1337.0, [1, 2, 3], {"key": "value", "key2": 5}, json_str)
+    items = (Path("test"), "test2", 42, 1337.0, [1, 2, 3], {"key": "value", "key2": 5}, json_str, None)
     cache_path_generator = (tmpdir / str(i) for i in range(5))
     serialized_items = serialization.serialize_item(items, cache_path_generator)
     assert serialized_items is not None
@@ -54,6 +54,7 @@ def test_serialize_deserialize_items(tmpdir):
     assert len(serialized_items[4]) == len(items[4])
     assert isinstance(serialized_items[5], dict)
     assert isinstance(serialized_items[6], str)
+    assert serialized_items[7] is None
 
     # Pass through JSON serialization to ensure we can save/load correctly
     serialized_items = json.loads(json.dumps(serialized_items, indent=4))


### PR DESCRIPTION
### Fixed
- Fixed a bug where recipes returning `None` (no return value) would not be correctly cached on subsequent runs