### PR TITLE
Use function docstrings to improve Lab CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a new `doc` property to recipes that provides a documentation string for the recipe. If not provided upon
+creation of a recipe, alkymi will try to infer the documentation string by parsing the bound function's docstring
+- Added a new optional `doc` argument to the `arg` recipe that provides a documentation string for the argument
+
 ### Changed
 - `stderr` is now streamed by default when using the `utils.call()` utility function [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
-- When utilizing the `Lab` CLI interface, alkymi will now omit alkymi internals from tracebacks resulting from
+- When utilizing the `Lab` command line interface, alkymi will now omit alkymi internals from tracebacks resulting from
 exceptions raised by user code (recipes) 
+- Refactored the `Lab` command line interface to provide rich information by making use of the new `doc` property on
+`Recipe` and `arg` instances
+- Changed the allowed arguments to `brew X` to only contain arguments that affect recipe `X`
 
 ### Fixed
 - Remove unnecessary decimal points in fancy progress output [#42](https://github.com/MathiasStokholm/alkymi/issues/42)
 - Fixed a bug where the terminal cursor would disappear if an exception was thrown during execution
 - Fixed a bug where the terminal cursor would disappear if a `Lab` call to `brew` was terminated using ctrl-c
 - Fixed a bug where recipes returning `None` (no return value) would not be correctly cached on subsequent runs
+
+### Removed
+- Removed the ability to brew multiple recipes from a `Lab` by listing them in succession
+
 
 ## [0.2.1] - 2023-04-27
 ### Fixed

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -21,7 +21,7 @@ OutputsAndChecksums = Tuple[R, Optional[str]]
 def create_graph(recipe: Recipe[R]) -> nx.DiGraph:
     """
     Create a Directed Acyclic Graph (DAG) based on the provided recipe
-    Each node in the graph represents a recipe, and has an associated "status" attribute
+    Each node in the graph represents a recipe
 
     :param recipe: The recipe to construct a graph for
     :return: The constructed graph

--- a/alkymi/foreach_recipe.py
+++ b/alkymi/foreach_recipe.py
@@ -24,7 +24,7 @@ class ForeachRecipe(Recipe[R]):
     """
 
     def __init__(self, mapped_recipe: Recipe, ingredients: Iterable[Recipe], func: Callable[..., R], name: str,
-                 transient: bool, cache: CacheType, cleanliness_func: Optional[CleanlinessFunc] = None):
+                 transient: bool, doc: str, cache: CacheType, cleanliness_func: Optional[CleanlinessFunc] = None):
         """
         Create a new ForeachRecipe
 
@@ -35,6 +35,7 @@ class ForeachRecipe(Recipe[R]):
         :param func: The function to bind to this recipe
         :param name: The name of this Recipe
         :param transient: Whether to always (re)evaluate the created Recipe
+        :param doc: Documentation string for this recipe
         :param cache: The type of caching to use for this Recipe
         :param cleanliness_func: A function to allow a custom cleanliness check
         """
@@ -44,7 +45,7 @@ class ForeachRecipe(Recipe[R]):
         self._mapped_inputs_checksum: Optional[str] = None
         self._mapped_outputs: Optional[MappedOutputs] = None
         self._mapped_outputs_checksum: Optional[str] = None
-        super().__init__(func, chain([mapped_recipe], ingredients), name, transient, cache, cleanliness_func)
+        super().__init__(func, chain([mapped_recipe], ingredients), name, transient, doc, cache, cleanliness_func)
 
     @property
     def mapped_inputs_type(self) -> Optional[type]:
@@ -217,7 +218,6 @@ class ForeachRecipe(Recipe[R]):
             mapped_inputs_checksum=self.mapped_inputs_checksum,
             mapped_type="dict" if self.mapped_inputs_type == dict else "list"
         )
-
 
     def restore_from_dict(self, old_state: Dict) -> None:
         """

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -233,7 +233,7 @@ class Lab:
         parser = argparse.ArgumentParser('CLI for {}'.format(self._name))
         parser.add_argument("-v", "--verbose", action="store_true", help="Turn on verbose logging")
 
-        subparsers = parser.add_subparsers(help='Available commands', dest='subparser_name')
+        subparsers = parser.add_subparsers(dest='subparser_name', metavar="")
 
         # Create the parser for the "status" command
         status_parser = subparsers.add_parser('status', help='Prints the detailed status of the lab')
@@ -245,12 +245,11 @@ class Lab:
                                  help="Use N jobs to evaluate the recipe, more than 1 job will parallelize evaluation")
         brew_parser.add_argument("--progress", type=ProgressType, default=ProgressType.Fancy,
                                  choices=list(ProgressType), help="The type of progress indication to use")
-        brew_subparsers = brew_parser.add_subparsers(help="Available recipes")
+        brew_subparsers = brew_parser.add_subparsers(metavar="")
 
         # Create a parser (command) for each recipe that can be brewed
         for recipe in self._recipes:
-            description = inspect.getdoc(recipe._func).split("\n\n")[0]
-            recipe_parser = brew_subparsers.add_parser(recipe.name, help=description, description=description,
+            recipe_parser = brew_subparsers.add_parser(recipe.name, help=recipe.doc, description=recipe.doc,
                                                        formatter_class=argparse.MetavarTypeHelpFormatter)
             recipe_parser.set_defaults(recipe=recipe.name)
 

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import sys
 import traceback
-import inspect
 from typing import Dict, Union, Any, List, Optional
 from typing import Iterable, TextIO
 

--- a/alkymi/lab.py
+++ b/alkymi/lab.py
@@ -236,7 +236,8 @@ class Lab:
         subparsers = parser.add_subparsers(dest='subparser_name', metavar="")
 
         # Create the parser for the "status" command
-        status_parser = subparsers.add_parser('status', help='Prints the detailed status of the lab')
+        status_parser = subparsers.add_parser('status', help='Prints the detailed status of the lab',
+                                              formatter_class=argparse.MetavarTypeHelpFormatter)
         self._add_user_args_(status_parser, self._args)
 
         # Create the parser for the "brew" command along with brew-specific arguments
@@ -276,7 +277,6 @@ class Lab:
                 arg.set(provided_val)
 
         if parsed_args.subparser_name == 'status':
-            # TODO: Allow setting all arguments for 'status' call?
             self.print_status()
         elif parsed_args.subparser_name == 'brew':
             # If not recipe was provided to brew, just print help

--- a/alkymi/recipe.py
+++ b/alkymi/recipe.py
@@ -24,7 +24,7 @@ class Recipe(Generic[R]):
 
     CACHE_DIRECTORY_NAME = ".alkymi_cache"
 
-    def __init__(self, func: Callable[..., R], ingredients: Iterable['Recipe'], name: str, transient: bool,
+    def __init__(self, func: Callable[..., R], ingredients: Iterable['Recipe'], name: str, transient: bool, doc: str,
                  cache: CacheType, cleanliness_func: Optional[CleanlinessFunc[R]] = None):
         """
         Create a new Recipe
@@ -34,6 +34,7 @@ class Recipe(Generic[R]):
         :param func: The function to bind to this recipe
         :param name: The name of this Recipe
         :param transient: Whether to always (re)evaluate the created Recipe
+        :param doc: Documentation string for this recipe
         :param cache: The type of caching to use for this Recipe
         :param cleanliness_func: A function to allow a custom cleanliness check
         """
@@ -41,6 +42,7 @@ class Recipe(Generic[R]):
         self._ingredients = list(ingredients)
         self._name = name
         self._transient = transient
+        self._doc = doc
         self._cleanliness_func = cleanliness_func
 
         # Set cache type based on default value (in AlkymiConfig)
@@ -167,6 +169,13 @@ class Recipe(Generic[R]):
         :return: Whether to always (re)evaluate the created Recipe
         """
         return self._transient
+
+    @property
+    def doc(self) -> str:
+        """
+        :return: The documentation string for this recipe
+        """
+        return self._doc
 
     @property
     def cache(self) -> CacheType:

--- a/alkymi/recipes.py
+++ b/alkymi/recipes.py
@@ -40,7 +40,7 @@ def glob_files(name: str, directory: Path, pattern: str, recursive: bool, cache=
             return False
         return _glob_recipe() == last_outputs
 
-    doc = f"Find and return files in {directory} with pattern '{pattern}'" + " recursively" if recursive else ""
+    doc = f"Find and return files in {directory} with pattern '{pattern}'" + (" recursively" if recursive else "")
     return Recipe(_glob_recipe, [], name, transient=False, doc=doc, cache=cache, cleanliness_func=_check_clean)
 
 

--- a/alkymi/recipes.py
+++ b/alkymi/recipes.py
@@ -119,17 +119,19 @@ class Arg(Recipe[T]):
     dirty and cause reevaluation of downstream recipe(s)
     """
 
-    def __init__(self, arg: T, name: str, cache=CacheType.Auto):
+    def __init__(self, arg: T, name: str, doc: str = "", cache=CacheType.Auto):
         """
         Create a new Arg instance with initial argument value
 
         :param arg: The initial argument value
         :param name: The name to give the created Recipe
+        :param doc: Documentation string for this argument - will be used in alkymi's Lab command line interface
         :param cache: The type of caching to use for this Recipe
         """
         self._arg = arg
         self._type = type(arg)
         self._subtype = next((type(val) for val in arg), None) if isinstance(arg, Iterable) else None
+        self._doc = doc
         super().__init__(self._produce_arg, [], name, transient=False, cache=cache, cleanliness_func=self._clean)
 
     @property
@@ -146,6 +148,13 @@ class Arg(Recipe[T]):
                  types
         """
         return self._subtype
+
+    @property
+    def doc(self) -> str:
+        """
+        :return: Documentation string for this argument
+        """
+        return self._doc
 
     def _produce_arg(self) -> T:
         """
@@ -173,13 +182,14 @@ class Arg(Recipe[T]):
         self._arg = _arg
 
 
-def arg(_arg: T, name: str, cache=CacheType.Auto) -> Arg[T]:
+def arg(_arg: T, name: str, doc: str, cache=CacheType.Auto) -> Arg[T]:
     """
     Shorthand for creating an ``Arg`` instance
 
     :param _arg: The initial argument to use
     :param name: The name to give the created Recipe
+    :param doc: Documentation string for this argument - will be used in alkymi's Lab command line interface
     :param cache: The type of caching to use for this Recipe
     :return: The created ``Arg`` instance
     """
-    return Arg(_arg, name=name, cache=cache)
+    return Arg(_arg, name=name, doc=doc, cache=cache)

--- a/docs/source/advanced/built_in_recipes.rst
+++ b/docs/source/advanced/built_in_recipes.rst
@@ -19,7 +19,8 @@ in some cases, custom cleanliness functions - see :ref:`custom_cleanliness`). Th
 * ``arg``: Creates a recipe that outputs a value. The recipe has a special ``set()``
   function that allows the user to later change the argument, potentially resulting in a need for re-evaluation. The
   ``Arg`` type can also be used to accept user input using alkymi's Lab functionality (see
-  :ref:`command_line_interface`)
+  :ref:`command_line_interface`). An optional `doc` argument can be passed to provide a documentation string for the
+  argument - this will automatically be used by alkymi's `Lab` type to create a more detailed CLI.
 
 .. note::
     All built-in recipes are described in detail in the :ref:`Built-in Recipes API reference <built_in_recipes_api>`

--- a/examples/cli/cli.py
+++ b/examples/cli/cli.py
@@ -1,0 +1,30 @@
+import time
+import alkymi as alk
+
+time_to_sleep_s = alk.arg(0, name="time_to_sleep_s", doc="The number of seconds to sleep")
+messages = alk.arg(["Hello alkymi"], name="messages", doc="Messages to display")
+
+
+@alk.recipe()
+def sleep_and_print(time_to_sleep_s: int, messages: str) -> None:
+    """
+    Sleep for a number of seconds before printing one or more messages
+
+    :param time_to_sleep_s: The number of seconds to sleep for
+    :param messages: The messages to print
+    """
+    time.sleep(time_to_sleep_s)
+    for message in messages:
+        print(message)
+
+
+def main():
+    lab = alk.Lab("cli")
+    lab.add_recipe(sleep_and_print)
+    lab.register_arg(time_to_sleep_s)
+    lab.register_arg(messages)
+    lab.open()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cli/cli.py
+++ b/examples/cli/cli.py
@@ -18,9 +18,20 @@ def sleep_and_print(time_to_sleep_s: int, messages: str) -> None:
         print(message)
 
 
+@alk.recipe()
+def print_only(messages: str) -> None:
+    """
+    Prints one or more messages
+
+    :param messages: The messages to print
+    """
+    for message in messages:
+        print(message)
+
+
 def main():
     lab = alk.Lab("cli")
-    lab.add_recipe(sleep_and_print)
+    lab.add_recipes(sleep_and_print, print_only)
     lab.register_arg(time_to_sleep_s)
     lab.register_arg(messages)
     lab.open()

--- a/tests/test_builtin_recipes.py
+++ b/tests/test_builtin_recipes.py
@@ -24,6 +24,7 @@ def test_builtin_glob(tmpdir, file_checksum_method: FileChecksumMethod):
     assert len(glob_recipe.ingredients) == 0
     assert glob_recipe.brew() == [test_file]
     assert glob_recipe.status() == Status.Ok
+    assert len(glob_recipe.doc) > 0
 
     # Altering the file should mark the recipe dirty
     # If using timestamps, ensure that writes doesn't happen at the exact same time
@@ -56,6 +57,7 @@ def test_builtin_file(tmpdir, file_checksum_method: FileChecksumMethod):
     assert len(file_recipe.ingredients) == 0
     assert file_recipe.brew() == test_file
     assert file_recipe.status() == Status.Ok
+    assert len(file_recipe.doc) > 0
 
     # Altering the file should mark the recipe dirty
     # If using timestamps, ensure that writes doesn't happen at the exact same time
@@ -139,6 +141,7 @@ def test_zip_results():
         return ["zero", "one", "two", "three"]
 
     zipped = alkymi.recipes.zip_results("zip_lists", (numbers, strings, spelled))
+    assert len(zipped.doc) > 0
     results = zipped.brew()
     assert isinstance(results, list)
     assert all(isinstance(result, tuple) for result in results)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,6 +136,42 @@ def test_parse_docstring_from_func() -> None:
     assert alk.decorators._parse_docstring_from_func(square_numpydoc) == "Square the provided value"
 
 
+def test_docstrings() -> None:
+    """
+    Test that the decorators parse docstrings correctly, but prefers user-provided values
+    """
+
+    @alk.recipe(doc="This is overridden")
+    def func_with_overridden_doc() -> None:
+        pass
+
+    assert func_with_overridden_doc.doc == "This is overridden"
+
+    @alk.recipe()
+    def func() -> None:
+        """
+        A proper docstring for this function
+        """
+        pass
+
+    assert func.doc == "A proper docstring for this function"
+
+    @alk.foreach(func, doc="This is overridden")
+    def foreach_with_overridden_doc() -> None:
+        pass
+
+    assert foreach_with_overridden_doc.doc == "This is overridden"
+
+    @alk.foreach(func)
+    def foreach() -> None:
+        """
+        A proper docstring for this function
+        """
+        pass
+
+    assert foreach.doc == "A proper docstring for this function"
+
+
 def test_brew():
     AlkymiConfig.get().cache = False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,7 +54,7 @@ def test_parse_docstring_from_func() -> None:
     # Test that a lambda with a preceding comment works
 
     # Square the provided value
-    square_lambda = lambda x: x ** 2
+    square_lambda = lambda x: x ** 2  # NOQA: Testing only
     assert alk.decorators._parse_docstring_from_func(square_lambda) == "Square the provided value"
 
     # Test that a single-line docstring works

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,6 +38,95 @@ def test_decorators():
     assert should_be_a_foreach_recipe.transient is False
 
 
+def test_parse_docstring_from_func() -> None:
+    """
+    Test the '_parse_docstring_from_func' function is able to parse function descriptions from various docstring formats
+    """
+    # Test that a lambda with a preceding comment works
+
+    # Square the provided value
+    square_lambda = lambda x: x ** 2
+    assert alk.decorators._parse_docstring_from_func(square_lambda) == "Square the provided value"
+
+    # Test that a single-line docstring works
+    def square_single_line(x: float) -> float:
+        """Square the provided value"""
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square_single_line) == "Square the provided value"
+
+    # Test that a reST docstring works
+    def square_rest(x: float) -> float:
+        """
+        Square the provided value
+
+        :param x: The value to square
+        :return: The squared value
+        """
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square_rest) == "Square the provided value"
+
+    # Test that a multiline reST docstring works
+    def square_rest_multiline(x: float) -> float:
+        """
+        Square the provided value
+        and return the result
+
+        :param x: The value to square
+        :return: The squared value
+        """
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(
+        square_rest_multiline) == "Square the provided value and return the result"
+
+    # Test that a reST docstring works, even without a blank newline between description and params
+    def square_rest_no_newline(x: float) -> float:
+        """
+        Square the provided value
+        :param x: The value to square
+        :return: The squared value
+        """
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square_rest_no_newline) == "Square the provided value"
+
+    # Test that a google docstring works
+    def square_google(x: float) -> float:
+        """
+        Square the provided value
+
+        Args:
+            x: The value to square.
+
+        Returns:
+            The squared value
+        """
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square_google) == "Square the provided value"
+
+    # Test that a numpydoc docstring works
+    def square_numpydoc(x: float) -> float:
+        """
+        Square the provided value
+
+        Parameters
+        ----------
+        x : float
+            The value to square
+
+        Returns
+        -------
+        float
+            The squared value
+        """
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square_numpydoc) == "Square the provided value"
+
+
 def test_brew():
     AlkymiConfig.get().cache = False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,6 +42,15 @@ def test_parse_docstring_from_func() -> None:
     """
     Test the '_parse_docstring_from_func' function is able to parse function descriptions from various docstring formats
     """
+    # Test that an empty docstring doesn't blow up
+
+    assert alk.decorators._parse_docstring_from_func(lambda x: x ** 2) == ""
+
+    def square(x: float) -> float:
+        return x ** 2
+
+    assert alk.decorators._parse_docstring_from_func(square) == ""
+
     # Test that a lambda with a preceding comment works
 
     # Square the provided value

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -210,3 +210,9 @@ def test_lab_omits_alkymi_internals_in_traceback(capsys: pytest.CaptureFixture) 
 
     # The traceback should not contain the following:
     assert 'alkymi/core.py' not in printed_error  # Any line related to the internal execution engine of alkymi
+
+
+def test_recipe_docstring_parse() -> None:
+    # Test no docstring (None)
+    # Test 'brew' but with no recipe prints help
+    pass

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -210,9 +210,3 @@ def test_lab_omits_alkymi_internals_in_traceback(capsys: pytest.CaptureFixture) 
 
     # The traceback should not contain the following:
     assert 'alkymi/core.py' not in printed_error  # Any line related to the internal execution engine of alkymi
-
-
-def test_recipe_docstring_parse() -> None:
-    # Test no docstring (None)
-    # Test 'brew' but with no recipe prints help
-    pass


### PR DESCRIPTION
### Added
- Added a new `doc` property to recipes that provides a documentation string for the recipe. If not provided upon
creation of a recipe, alkymi will try to infer the documentation string by parsing the bound function's docstring
- Added a new optional `doc` argument to the `arg` recipe that provides a documentation string for the argument

### Changed
- Refactored the `Lab` command line interface to provide rich information by making use of the new `doc` property on
`Recipe` and `arg` instances
- Changed the allowed arguments to `brew X` to only contain arguments that affect recipe `X`

### Removed
- Removed the ability to brew multiple recipes from a `Lab` by listing them in succession