### PR TITLE
Fixed asyncio warnings on exception(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed readthedocs.org documentation build now requiring a .readthedocs.yaml config file
 - Fixed a bug where the actual error message from an exception happening during execution through a `Lab` instance would
 be omitted
+- Fixed an issue where exceptions in recipes could cause asyncio to print warning information about the `_schedule`
+coroutine never being awaited
+- Fixed an issue where asyncio would warn about exceptions not having been retrieved from futures when more than one
+exception was raised during parallel execution. Alkymi will now just raise the first exception it encounters. 
 
 
 ## [0.3.0] - 2024-04-23

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -354,6 +354,13 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
+        if jobs > 1:
+            # Set a noop exception handler to avoid warnings about exceptions that were not retrieved. Only the first
+            # exception will be raised by alkymi to the caller
+            def _exception_handler(_, __):
+                pass
+            loop.set_exception_handler(_exception_handler)
+
         async def _execute() -> OutputsAndChecksums[R]:
             # Sort the graph topographically, such that any recipe in the sorted list only depends on earlier recipes
             # This guarantees that futures only depend on already created futures
@@ -369,12 +376,13 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
                                                    progress)
 
             # Wait for future for target recipe to return
-            result = await coros_or_tasks[recipe]
-
-            # Close coroutines that were not converted to tasks, since they were never needed for the execution
-            for coro_or_task in coros_or_tasks.values():
-                if asyncio.iscoroutine(coro_or_task):
-                    coro_or_task.close()
+            try:
+                result = await coros_or_tasks[recipe]
+            finally:
+                # Close coroutines that were not converted to tasks, since they were never needed for the execution
+                for coro_or_task in coros_or_tasks.values():
+                    if asyncio.iscoroutine(coro_or_task):
+                        coro_or_task.close()
 
             return result
 

--- a/alkymi/core.py
+++ b/alkymi/core.py
@@ -357,8 +357,11 @@ def evaluate_recipe(recipe: Recipe[R], graph: nx.DiGraph, statuses: Dict[Recipe,
         if jobs > 1:
             # Set a noop exception handler to avoid warnings about exceptions that were not retrieved. Only the first
             # exception will be raised by alkymi to the caller
-            def _exception_handler(_, __):
-                pass
+            def _exception_handler(_, context: Dict[str, Any]):
+                # context["message"] will always be there; but context["exception"] may not
+                msg = context.get("exception", context["message"])
+                log.debug(f"Exception during parallel execution: '{msg}'")
+
             loop.set_exception_handler(_exception_handler)
 
         async def _execute() -> OutputsAndChecksums[R]:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -246,3 +246,18 @@ def test_brew_running_event_loop() -> None:
 
     # The "run" call here will set up and run and event loop, which will then call "_call"
     assert alk.utils.run_on_thread(lambda: asyncio.run(_call()))() == 42
+
+
+def test_parallel_exception(capsys: pytest.CaptureFixture) -> None:
+    """
+    Test that multiple exceptions raising in parallel will just raise the first exception without any warnings
+    """
+
+    values = alk.arg([1, 2, 3, 4, 5], name="values")
+
+    @alk.foreach(values)
+    def fail_on_each(value: int) -> None:
+        raise RuntimeError(value)
+
+    with pytest.raises(RuntimeError):
+        fail_on_each.brew(jobs=5)


### PR DESCRIPTION
### Fixed
- Fixed an issue where exceptions in recipes could cause asyncio to print warning information about the `_schedule`
coroutine never being awaited
- Fixed an issue where asyncio would warn about exceptions not having been retrieved from futures when more than one
exception was raised during parallel execution. Alkymi will now just raise the first exception it encounters. 